### PR TITLE
Add GitHub Pages index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # test
+
+Ce dépôt contient une page statique destinée à GitHub Pages.
+
+- [`index.html`](index.html) : page de test principale.
+- [`admin.html`](admin.html) : exemple de tableau de bord.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page de test</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-100 text-gray-900">
+    <header class="bg-blue-600 text-white p-4">
+        <h1 class="text-2xl font-bold">Bienvenue sur la page de test</h1>
+    </header>
+    <main class="p-4">
+        <p class="mb-4">Ceci est une page simple pour tester GitHub Pages.</p>
+        <p class="mb-4">Vous pouvez également consulter la <a href="admin.html" class="text-blue-600 underline">page d'administration</a>.</p>
+    </main>
+    <footer class="bg-gray-200 p-4 text-center">
+        <p>Page de test hébergée via GitHub Pages.</p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an index.html page with Tailwind for GitHub Pages
- update README with links to the pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684070ae7c908330b9d3d31d5a994930